### PR TITLE
Fix slowness for very quick loops

### DIFF
--- a/src/ProgressBars.jl
+++ b/src/ProgressBars.jl
@@ -32,6 +32,7 @@ mutable struct ProgressBar
   current::Int
   width::Int
   start_time::UInt
+  last_print::UInt
   description::AbstractString
 
   function ProgressBar(wrapped::Any; total::Int = -1, width = 100)
@@ -39,6 +40,7 @@ mutable struct ProgressBar
     this.wrapped = wrapped
     this.width = width
     this.start_time = time_ns()
+    this.last_print = this.start_time
     this.total = length(wrapped)
     this.description = ""
     return this
@@ -129,7 +131,10 @@ end
 
 function Base.iterate(iter::ProgressBar,s)
   iter.current += 1
-  display_progress(iter)
+  if(time_ns() - iter.last_print > 0.05 * 1e9)
+    display_progress(iter)
+    iter.last_print = time_ns()
+  end
   state = iterate(iter.wrapped,s)
   if state===nothing
     iter.current = iter.total

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,3 +18,11 @@ for i in iter
   set_description(iter, string(@sprintf("Loss: %.2f", loss)))
 end
 @test true
+
+iter = ProgressBar(1:100000)
+tic = time_ns()
+for i in iter
+  i = i * 2
+end
+toc = time_ns()
+@test (toc - tic) / 1e9 < 1


### PR DESCRIPTION
Keep track of when the progressbar was last printed and prevent updating it too often. Fixes #7.

Added a test-case for this as well.