### PR TITLE
Add leave argument similar to tqdm

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,14 @@ for i in iter
 end
 @test true
 
+# Test with leave=false
+iter = ProgressBar(1:1000, leave=false)
+for i in iter
+  sleep(0.001)
+end
+@test true
+
+
 iter = ProgressBar(1:1000)
 tic = time_ns()
 for i in iter


### PR DESCRIPTION
Hello! Thanks for the useful package.

I am working on a few shot learning problem which requires me to do go over a small dataset multiples times in quick succession, and my terminal quickly got cluttered with all the progress bars. I thought it would be pretty convenient to have a similar "leave" argument to the python package which clears the progressbar after iteration is done. I've implemented it locally and I thought others might also find it convenient.

It's a minor modification. I simply added a leave keyword argument identical to that in python. After iteration is done, if the leave argument is false, I reset the cursor, delete the output line (by printing width number of spaces), then reset the cursor again.

Here's a sample usage:

With leave=true (Exact same functionality as before)
```julia
> for i in ProgressBar(1:8)
>     i*i
> end
> println("Done")
100.0%┣██████████████████████████████████████████┫ 8/8 [00:00<00:00, 110.7 it/s]
Done 
```

With leave=false
```julia
> for i in ProgressBar(1:8, leave=false)
>     i*i
> end
> println("Done")
Done 
```