### PR TITLE
Add multi-line postfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ julia> iter = ProgressBar(1:100)
        end
 100.0%┣████████████████████████████████████████████┫ 1000/1000 [00:02<00:00, 420.4 it/s, Loss: 0.37]
 ```
+You can also use multi-line postfixes, like so:
+```julia
+julia> iter = ProgressBar(1:100)
+       for i in iter
+          # ... Neural Network Training Code
+          loss = exp(-i)
+          set_multiline_postfix(iter, "Test 1: $(rand())\nTest 2: $(rand())\nTest 3: $loss)")
+       end
+100.0%┣████████████████████████████████████████████┫ 1000/1000 [00:02<00:00, 420.4 it/s]
+Test1: 0.6740503146383823
+Test2: 0.23694728303439727
+Test3: 0.06787944117144233
+```
 
 Now with added support for `Threads.@threads for`:
 

--- a/src/ProgressBars.jl
+++ b/src/ProgressBars.jl
@@ -26,7 +26,7 @@ IDLE = collect("╱   ")
 
 PRINTING_DELAY = 0.05 * 1e9
 
-export ProgressBar, tqdm, set_description, set_postfix
+export ProgressBar, tqdm, set_description, set_postfix, set_multiline_postfix
 """
 Decorate an iterable object, returning an iterator which acts exactly
 like the original iterable, but prints a dynamically updating
@@ -308,6 +308,25 @@ function Base.getindex(iter::ProgressBar, index::Int64)
   end
   unlock(iter.mutex)
   return item
+end
+
+function newline_to_spaces(string, terminal_width)
+  new_string = ""
+  width_cumulator = 0
+  for c in string
+    if c == '\n'
+      spaces_required = terminal_width - width_cumulator
+      new_string *= " "^spaces_required
+      width_cumulator = 0
+    else
+      new_string *= c
+      width_cumulator += 1
+    end
+    if width_cumulator == terminal_width
+      width_cumulator = 0
+    end
+  end
+  return new_string
 end
 
 end # module

--- a/src/ProgressBars.jl
+++ b/src/ProgressBars.jl
@@ -180,9 +180,17 @@ function Base.iterate(iter::ProgressBar)
   return iterate(iter.wrapped)
 end
 
-function Base.iterate(iter::ProgressBar,s)
+make_space_after_progress_bar() = print("\n"^2)
+
+function Base.iterate(iter::ProgressBar,s)  
   iter.current += 1
   if(time_ns() - iter.last_print > PRINTING_DELAY)
+    current_terminal_width = displaysize(stdout)[2]
+    terminal_width_changed = current_terminal_width != iter.width
+    if terminal_width_changed
+      iter.width = current_terminal_width
+      make_space_after_progress_bar()
+    end
     display_progress(iter)
     iter.last_print = time_ns()
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,25 @@ for i in iter
   set_postfix(iter, Loss=@sprintf("%.2f", loss))
 end
 @test true
+#
+# Test with multiline postfix
+iter = ProgressBar(1:1000)
+for i in iter
+  sleep(0.001)
+  loss = exp(-i / 1000)
+  set_multiline_postfix(iter, "Test 1: $(rand())\nTest 2: $(rand())\nTest 3: $loss")
+end
+@test true
+#
+# Test with both postfixes
+iter = ProgressBar(1:1000)
+for i in iter
+  sleep(0.001)
+  loss = exp(-i / 1000)
+  set_postfix(iter, Loss=@sprintf("%.2f", loss))
+  set_multiline_postfix(iter, "Test 1: $(rand())\nTest 2: $(rand())\nTest 3: $loss")
+end
+@test true
 
 # Test with leave=false
 iter = ProgressBar(1:1000, leave=false)


### PR DESCRIPTION
(To be merged after #34; since it includes the same commits)

Best explained with a demo:

![progress_bars (1)](https://user-images.githubusercontent.com/7593028/109073961-16516500-76c5-11eb-8e74-0fdf31426a1c.gif)

I also added a change which changes the main functionality, explained below. I am open to removing this or adding a flag to enable it.

Basically, it will print another newline after the ProgressBar, regardless of if there is a postfix or not. It uses the escape sequences to move back up afterwards, so the printing should still be the same.

The reason I added this is to increase compatibility with other tools that capture stdout. Many tools watch for the "\n" key when they read from a stream, and otherwise will just hang for a while until the progress bar is complete. But with the progress bar printing "\n" after every iteration, tools that capture the stream using "\n" by default as the stream separator will now be able to display the progress bar. The visual difference to note is that this will make an extra space after the progress bar.